### PR TITLE
削除操作の仕様を変更：子ノードを持つノードの削除を分離した

### DIFF
--- a/components/TreeNode.vue
+++ b/components/TreeNode.vue
@@ -59,10 +59,17 @@ export default {
         this.addChildNode();
       } else if (event.key === 'd'){
         this.deleteThisNode();
+      } else if (event.key === 'D'){
+        this.deleteThisNodeForce();
       }
     },
+    deleteThisNodeForce(){
+      this.$emit("deleteMe");
+    },
     deleteThisNode(){
+      if(this.node.children.length==0){
         this.$emit("deleteMe");
+      }
     },
     deleteChildNode(index){
       let target = this.$refs.childrenComponent[index].node;


### PR DESCRIPTION
# 変更点
## 変更前
dキーを押すと，ノードを削除する．
対象のノードは任意のノードで，子ノードを持つノードを削除すると，
子ノードも削除されていた．
## 変更後
dキーを押すと，そのノードが子ノードを持たない末端のノードだった場合のみ削除できる．
従来と同じ，任意のノードを削除できる削除は，Dを押したときにするようにした．