### PR TITLE
ノードの追加についての動作を変更．

### DIFF
--- a/components/TreeNode.vue
+++ b/components/TreeNode.vue
@@ -23,6 +23,8 @@
         :node="childNode" 
         @activePrevSibling="()=>activateChildNode(index-1)"
         @activeNextSibling="()=>activateChildNode(index+1)"
+        @addPrevSibling="()=>addChildNode(index)"
+        @addNextSibling="()=>addChildNode(index+1)"
         @deleteMe="()=>deleteChildNode(index)"/>
     </div>
   </div>
@@ -58,8 +60,10 @@ export default {
       } else if (event.key === 'i') {
         this.activateEditMode();
       } else if (event.key === 'o') {
-        this.addSiblingNode();
+        this.addNextSiblingNode();
       } else if (event.key === 'O') {
+        this.addPrevSiblingNode();
+      } else if (event.key === '>') {
         this.addChildNode();
       } else if (event.key === 'd'){
         this.deleteThisNode();
@@ -95,15 +99,14 @@ export default {
         }
       });
     },
-    addSiblingNode(){
-      const parentNode = this.$parent;
-      if (parentNode && parentNode.activate) {
-        parentNode.addChildNode();
-      }
+    addPrevSiblingNode(){
+      this.$emit("addPrevSibling");
     },
-    addChildNode(){
-      this.node.newChild("new node");
-      let newNodeIndex = this.node.children.length-1
+    addNextSiblingNode(){
+      this.$emit("addNextSibling");
+    },
+    addChildNode(newNodeIndex = this.node.children.length){
+      this.node.newChild(newNodeIndex,"new node");
 
       this.$nextTick(()=>{
         this.$refs.childrenComponent[newNodeIndex].activate();

--- a/models/LogicTree.ts
+++ b/models/LogicTree.ts
@@ -7,9 +7,9 @@ export class Node{
     this.children = [];
   }
 
-  newChild(label: string){
+  newChild(index:Number, label: string){
     let childNode = new Node(label);
-    this.addChild(childNode);
+    this.children.splice(index,0,childNode);
   }
 
   addChild(node: Node): void {


### PR DESCRIPTION
# 実装した仕様
- 'o'でフォーカスしているノードの直下に新しいノードを追加．(従来は一番下だった)
- 'O'で直上に新しいノードを追加．
- '>'で子ノード追加.

# デモ
https://github.com/Tomitomi1021/LogicTree/assets/29561529/34114fa9-88fa-455d-aaeb-4ad9cea68c5f

