### PR TITLE
midIndexの計算方法を修正した．

### DIFF
--- a/components/TreeNode.vue
+++ b/components/TreeNode.vue
@@ -119,13 +119,17 @@ export default {
       const nodeCountSum = nodeCounts.reduce((a,x)=>a+x);
 
       let nodeCountCumulativeSum = 0;
-      for(let i=0;i<nodeCounts.length;i++){
+      let distances=[]
+      for(let i=0;i<=nodeCounts.length;i++){
+        const firstHalfNodeCount = nodeCountCumulativeSum;
+        const secondHalfNodeCount = nodeCountSum - nodeCountCumulativeSum;
+
+        distances.push(Math.abs(firstHalfNodeCount - secondHalfNodeCount));
+
         nodeCountCumulativeSum += nodeCounts[i];
-        if(nodeCountCumulativeSum > nodeCountSum-nodeCountCumulativeSum){
-          return i;
-        }
       }
-      return this.node.children.length;
+
+      return distances.indexOf(Math.min(...distances));
     },
     nodeCount(){
       return this.node.children.length;


### PR DESCRIPTION
# 解決したIssue
#18 

# スクリーンショット
## #18で指摘されたパターン
![image](https://github.com/Tomitomi1021/LogicTree/assets/29561529/bbbf57e2-36e0-46c6-9a42-47f2d49eb27f)
## さらにノードを増やしたパターン
![image](https://github.com/Tomitomi1021/LogicTree/assets/29561529/5ab2f1db-607b-4935-8ac4-712002985f41)
## 逆にChild2にノードを増やしたパターン
![image](https://github.com/Tomitomi1021/LogicTree/assets/29561529/9e429b82-ca80-4623-9361-99430a6aab61)
