### PR TITLE
contentWidthが変動した際に，そのノード以下のノードを全てforceUpdateするようにした．

### DIFF
--- a/components/TreeNode.vue
+++ b/components/TreeNode.vue
@@ -79,6 +79,9 @@ export default {
   watch:{
     nodeId(newValue,oldValue){
       this.node = NuxtAdapterProvider.get().instanceStorage.getInstance(this.nodeId);
+    },
+    contentWidth(newValue,oldValue){
+      this.parentContentWidthChanged();
     }
   },
   computed:{
@@ -136,6 +139,19 @@ export default {
     }
   },
   methods: {
+    parentContentWidthChanged(){
+      this.$forceUpdate();
+      if(this.$refs.childrenComponentFirstHalf !== undefined){
+        this.$refs.childrenComponentFirstHalf.forEach((child)=>{
+          child.parentContentWidthChanged();
+        });
+      }
+      if(this.$refs.childrenComponentSecondHalf !== undefined){
+        this.$refs.childrenComponentSecondHalf.forEach((child)=>{
+          child.parentContentWidthChanged();
+        });
+      }
+    },
     handleKeyDown(event) {
       if(this.model.editMode){
         if (event.key === 'Escape' || event.key === 'Enter'){


### PR DESCRIPTION
# 解決したISSUE
#21 

# デモ
https://github.com/Tomitomi1021/LogicTree/assets/29561529/40e6cbdc-bae1-4008-a856-76cb229d08c0

#備考
forceUpdateを使ってしまっているので，もっといい方法があったらそれを使いたい．
現状想像される原因は，ロジックをモデルに分離したことで子ノードのコンポーネントが親コンポーネントの何かしらの変更をとらえられなくなったから，親ノードを編集しても，子ノードのコンポーネントが再描画されなくなったのではないかという原因．
そして，線のコンポーネント（LeaderLine）は現状，再描画をトリガーにして更新しているので，再描画されないと線も更新されないので線の位置がそのままになっている．（ここまであくまで仮説）

少なくとも，ロジックを分離したことで，親ノードを編集しても子ノードのコンポーネントが再描画されなくなったのは事実．