### PR TITLE
TreeNodeのテンプレートを，全体的にflexを用いた形に修正した．

### DIFF
--- a/components/LeaderLine.vue
+++ b/components/LeaderLine.vue
@@ -96,18 +96,11 @@ export default {
       const topY    = (sy+sh/2 < ey+eh/2)? sy+sh/2 : ey+eh/2;
       const bottomY = (sy+sh/2 > ey+eh/2)? sy+sh/2 : ey+eh/2;
 
-      //高さが全く同じ場合は考えないものとする．
-      if(topY==bottomY){
-        return {
-          isValid: false
-        };
-      }else{
-        return {
-          isValid: true,
-          topY: topY,
-          bottomY: bottomY
-        };
-      }
+      return {
+        isValid: true,
+        topY: topY,
+        bottomY: bottomY
+      };
     },
 
 

--- a/components/TreeNode.vue
+++ b/components/TreeNode.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="tree-node">
-    <div class="padding"></div>
     <div class="flex">
 
       <div v-if="node.parent!==null" class="lines">
@@ -31,11 +30,12 @@
         <TreeNode 
           ref="childrenComponents"
           v-for="(childNode,index) in node.children.slice(0,node.children.length)" 
-          :nodeId="childNode" />
+          :nodeId="childNode" 
+          :paddingRequired="index<(node.children.length-1)" />
       </div>
 
     </div>
-    <div class="padding"></div>
+    <div v-if="paddingRequired" class="padding"></div>
   </div>
 </template>
 
@@ -49,6 +49,10 @@ export default {
     nodeId: {
       type: String,
       required: true,
+    },
+    paddingRequired: {
+      type: Boolean,
+      required: false,
     }
   },
   data(){
@@ -169,7 +173,7 @@ export default {
 
 <style scoped>
 .padding{
-  height:0.5em;
+  height:1em;
 }
 
 .flex{

--- a/components/TreeNode.vue
+++ b/components/TreeNode.vue
@@ -2,41 +2,38 @@
   <div class="tree-node">
     <div class="padding"></div>
     <div class="flex">
-      <div :style="{width:contentWidth+'px'}" ></div>
-      <div class="line"></div>
+
+      <div v-if="node.parent!==null" class="lines">
+        <LeaderLine 
+          ref="leaderLine" 
+          :start="startPoint" 
+          :end="endPoint"/> 
+      </div>
+
+      <div class="node">
+        <input 
+          ref="nodeLabel" 
+          v-model="node.label"
+          @compositionstart="compositionStart"
+          @compositionend="compositionEnd"
+          @compositionupdate="compositionUpdate"
+          @keydown="handleKeyDown"
+          @click="activate()"
+          @blur="onEditorBlur"
+          tabindex="0"
+          :class="['node-label',(isEditMode)?'node-label-editing':(isOnCursor)?'node-label-oncursor':'']"
+          :readonly="!isEditMode"
+          :style="{width:contentWidth+'px'}"
+          type="text">
+      </div>
+
       <div class="children">
         <TreeNode 
-          ref="childrenComponentFirstHalf"
-          v-for="(childNode,index) in node.children.slice(0,midIndex)" 
+          ref="childrenComponents"
+          v-for="(childNode,index) in node.children.slice(0,node.children.length)" 
           :nodeId="childNode" />
       </div>
-    </div>
 
-    <LeaderLine ref="leaderLine" :start="startPoint" :end="endPoint"/> 
-    <input 
-      ref="nodeLabel" 
-      v-model="node.label"
-      @compositionstart="compositionStart"
-      @compositionend="compositionEnd"
-      @compositionupdate="compositionUpdate"
-      @keydown="handleKeyDown"
-      @click="activate()"
-      @blur="onEditorBlur"
-      tabindex="0"
-      :class="(isOnCursor)?(isEditMode)?'node-label-editing':'node-label-oncursor':'node-label'"
-      :readonly="!isEditMode"
-      :style="{width:contentWidth+'px'}"
-      type="text">
-
-    <div class="flex">
-      <div :style="{width:contentWidth+'px'}" ></div>
-      <div class="line"></div>
-      <div class="children">
-        <TreeNode 
-          ref="childrenComponentSecondHalf"
-          v-for="(childNode,index) in node.children.slice(midIndex,nodeCount)" 
-          :nodeId="childNode" />
-      </div>
     </div>
     <div class="padding"></div>
   </div>
@@ -64,7 +61,9 @@ export default {
     }
   },
   updated(){
-    this.$refs.leaderLine.update();
+    if(this.$refs.leaderLine!==undefined){
+      this.$refs.leaderLine.update();
+    }
     if(this.isOnCursor){
       this.$refs.nodeLabel.focus();
     }
@@ -105,43 +104,6 @@ export default {
 
       return width;
     },
-    midIndex(){
-      if(this.node.children.length==0){
-        return 0;
-      }
-
-      const nodeCounts = this.node.children.map(childId => {
-        function count(nodeId,model){
-          const children = model.getChildren(nodeId);
-          if(children.length==0){
-            return 1;
-          }else{
-            return children
-                    .map((c)=>count(c,model))
-                    .reduce((a,x)=>a+x);
-          }
-        }
-        return count(childId,this.model);
-      });
-
-      const nodeCountSum = nodeCounts.reduce((a,x)=>a+x);
-
-      let nodeCountCumulativeSum = 0;
-      let distances=[]
-      for(let i=0;i<=nodeCounts.length;i++){
-        const firstHalfNodeCount = nodeCountCumulativeSum;
-        const secondHalfNodeCount = nodeCountSum - nodeCountCumulativeSum;
-
-        distances.push(Math.abs(firstHalfNodeCount - secondHalfNodeCount));
-
-        nodeCountCumulativeSum += nodeCounts[i];
-      }
-
-      return distances.indexOf(Math.min(...distances));
-    },
-    nodeCount(){
-      return this.node.children.length;
-    }
   },
   methods: {
     compositionStart(){
@@ -155,13 +117,8 @@ export default {
     },
     parentContentWidthChanged(){
       this.$forceUpdate();
-      if(this.$refs.childrenComponentFirstHalf !== undefined){
-        this.$refs.childrenComponentFirstHalf.forEach((child)=>{
-          child.parentContentWidthChanged();
-        });
-      }
-      if(this.$refs.childrenComponentSecondHalf !== undefined){
-        this.$refs.childrenComponentSecondHalf.forEach((child)=>{
+      if(this.$refs.childrenComponents!== undefined){
+        this.$refs.childrenComponents.forEach((child)=>{
           child.parentContentWidthChanged();
         });
       }
@@ -211,71 +168,51 @@ export default {
 </script>
 
 <style scoped>
-.tree-node {
+.padding{
+  height:0.5em;
+}
+
+.flex{
+  display:flex;
+  align-items:center;
+}
+
+.lines{
+  width:40px;
+  height:auto;
+  margin:0;
+  padding:0;
+}
+
+.node {
+}
+
+.children {
 }
 
 .node-label {
-  margin:0;
   padding-top:0;
   padding-bottom:0;
-  border: solid black 1px;
-  border-radius: 5px;
   padding-left:5px;
   padding-right:10px;
+
+  border: solid black 1px;
+  border-radius: 5px;
+
   height:1.5em;
-  width:fit-content;
+
   font-weight: bold;
   font-size:16pt;
   font-family: "Noto Sans", sans-serif;
 }
 
 .node-label-oncursor {
-  margin:0;
-  padding-top:0;
-  padding-bottom:0;
-  border: solid black 1px;
-  border-radius: 5px;
-  padding-left:5px;
-  padding-right:10px;
-  height:1.5em;
-  width:fit-content;
-  font-weight: bold;
-  font-size:16pt;
-  font-family: "Noto Sans", sans-serif;
-  font-weight: bold;
   background-color: yellow;
 }
 
 .node-label-editing {
-  margin:0;
-  padding-top:0;
-  padding-bottom:0;
-  border: solid black 1px;
-  border-radius: 5px;
-  padding-left:5px;
-  padding-right:10px;
-  height:1.5em;
-  width:fit-content;
-  font-weight: bold;
-  font-size:16pt;
-  font-family: "Noto Sans", sans-serif;
-  font-weight: bold;
   background-color: aquamarine;
 }
 
-.children {
-}
-
-.padding{
-  height:5px;
-}
-
-.flex{
-  display:flex;
-}
-
-.line{
-  width:3em;
-}
 </style>
 


### PR DESCRIPTION
# 変更内容
元々，TreeNodeの主要な階層はflexじゃなくて，子要素，ノード，子要素という縦の並びでツリーを実現していた．
そこを，flexにして，線，ノード，子要素の横の並びに書き直した．
また，これによってmidIndexの計算が不要になったので削除した．

リファクタリングと言いつつ，見た目が変わっている．
具体的には，親ノードが子要素の集合に対して中心に来るようになった．
今まではmidIndexを用いてできるだけ中心に近い位置に来るようにしていた．
それに伴って，子ノードが一個の時は，親ノードと子ノードが一直線に並ぶようになった．

# 解決したISSUE
#27 