### PR TITLE
サーバ側でdocumentが無いというエラーが出ていたのを解決．

### DIFF
--- a/components/TreeNode.vue
+++ b/components/TreeNode.vue
@@ -73,6 +73,10 @@ export default {
     }
   },
   mounted(){
+    //サーバサイドではcontentWidthが計算できないので0になっている．
+    //そのため，mountedのタイミングでcontentWidthを強制的に再計算させる．
+    this.$forceUpdate()
+
     this.$nextTick(()=>{
       if(this.$parent.$refs.nodeLabel!==undefined){
         this.startPoint = this.$parent.$refs.nodeLabel;
@@ -99,14 +103,18 @@ export default {
       return this.model.editMode && this.isOnCursor;
     },
     contentWidth(){
-      const canvas = document.createElement("canvas");
-      const context = canvas.getContext('2d');
-      
-      context.font = "bold 16pt 'Noto Sans','sans-serif'"
-      const width = context.measureText(
-                      this.node.label+this.inputtingData).width;
+      if(process.client){
+        const canvas = document.createElement("canvas");
+        const context = canvas.getContext('2d');
+        
+        context.font = "bold 16pt 'Noto Sans','sans-serif'"
+        const width = context.measureText(
+                        this.node.label+this.inputtingData).width;
 
-      return width;
+        return width;
+      }else{
+        return 0;
+      }
     },
   },
   methods: {


### PR DESCRIPTION
# 解決前
yarn generate時
![image](https://github.com/Tomitomi1021/LogicTree/assets/29561529/4c61ef2c-df01-4da1-8c23-06c252368576)
yarn dev時
![image](https://github.com/Tomitomi1021/LogicTree/assets/29561529/7d52ba90-003f-4971-8bfc-5b276f64339b)

# 概要
以上のエラーを解決した．

具体的には，contentWidthの計算が問題になっていたので，
contentWidthをクライアントサイドでのみ計算するようにした．
その際，一部のノードでcontentWidthが0になる不具合があったので，mounted時に，一度強制的に更新をかけることで，
再計算させるようにした．